### PR TITLE
Fixing lint errors shown up on Android build

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,9 @@ version="0.1.2">
 
 <config-file target="AndroidManifest.xml" parent="/manifest">
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+</config-file>
+
+<config-file target="AndroidManifest.xml" parent="/manifest/application">
     <receiver android:name="org.apache.cordova.plugin.SmsReceiver" android:exported="true">
         <intent-filter android:priority="999">
             <action android:name="android.provider.Telephony.SMS_RECEIVED"></action>


### PR DESCRIPTION
The Lint errors seen on cordova android build were:

```
:lintVitalRelease/apps/jobs/Mobile-Android-Dev/workspace/Cordova/platforms/android/AndroidManifest.xml:70: Error: The <receiver> element must be a direct child of the <application> element [WrongManifestParent]
    <receiver android:exported="true" android:name="org.apache.cordova.plugin.SmsReceiver">
    ^

   Explanation for issues of type "WrongManifestParent":
   The <uses-library> element should be defined as a direct child of the
   <application> tag, not the <manifest> tag or an <activity> tag. Similarly,
   a <uses-sdk> tag much be declared at the root level, and so on. This check
   looks for incorrect declaration locations in the manifest, and complains if
   an element is found in the wrong place.

   http://developer.android.com/guide/topics/manifest/manifest-intro.html

1 errors, 0 warnings
 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':lintVitalRelease'.
> Lint found fatal errors while assembling a release target.

  To proceed, either fix the issues identified by lint, or modify your build script as follows:
  ...
  android {
      lintOptions {
          checkReleaseBuilds false
          // Or, if you prefer, you can continue to check for errors in release builds,
          // but continue the build even when errors are found:
          abortOnError false
      }
  }
```
